### PR TITLE
Query view

### DIFF
--- a/Monitor/monitor_app/app.py
+++ b/Monitor/monitor_app/app.py
@@ -2,7 +2,7 @@
 # Imports.
 #----------------------------------------------------------------------------#
 
-from flask import Flask, render_template, jsonify, flash, request, redirect, url_for, Response, make_response  # do not use '*'; actually input the dependencies.
+from flask import Flask, render_template, jsonify, flash, request, redirect, url_for, Response, make_response
 from flask.ext.sqlalchemy import SQLAlchemy
 import logging
 from logging import Formatter, FileHandler
@@ -12,14 +12,15 @@ import json
 import pymongo
 from bson import json_util
 import base64
+from appinit import app, db
 
 #----------------------------------------------------------------------------#
 # App Config.
 #----------------------------------------------------------------------------#
 
-app = Flask(__name__)
-app.config.from_object('config')
-db = SQLAlchemy(app)
+# app = Flask(__name__)
+# app.config.from_object('config')
+# db = SQLAlchemy(app)
 
 # Automatically tear down SQLAlchemy.
 '''
@@ -30,16 +31,16 @@ def shutdown_session(exception=None):
 
 # Login required decorator.
 
-
-def login_required(test):
-    @wraps(test)
-    def wrap(*args, **kwargs):
-        if 'logged_in' in session:
-            return test(*args, **kwargs)
-        else:
-            flash('You need to login first.')
-            return redirect(url_for('login'))
-    return wrap
+#
+# def login_required(test):
+#     @wraps(test)
+#     def wrap(*args, **kwargs):
+#         if 'logged_in' in session:
+#             return test(*args, **kwargs)
+#         else:
+#             flash('You need to login first.')
+#             return redirect(url_for('login'))
+#     return wrap
 
 
 @app.route('/dbstats')
@@ -175,7 +176,7 @@ def mongo_query(coll_name):
     """
     try:
         conf = models.Configuration.query.first()
-        conn = pymongo.MongoClient(conf.mongohost)
+        conn = pymongo.MongoClient(app.config["MEDIACLOUD_DATABASE_HOST"])
         db = conn.MCDB
         coll = db[coll_name]
         resp = {}
@@ -193,8 +194,8 @@ def mongo_query(coll_name):
         json_response = json.dumps({'data': fix_json_output(resp), 'meta': {'count': cnt}}, default=pymongo.json_util.default)
     except Exception as e:
         app.logger.error(repr(e))
-        import traceback
-        traceback.print_stack()
+        # import traceback
+        # traceback.print_stack()
         json_response = json.dumps({'error': repr(e)})
     finally:
         conn.disconnect()

--- a/Monitor/monitor_app/appinit.py
+++ b/Monitor/monitor_app/appinit.py
@@ -1,0 +1,10 @@
+#-*- coding:utf-8 -*-
+from flask import Flask
+from flask.ext.sqlalchemy import SQLAlchemy
+#----------------------------------------------------------------------------#
+# App Config.
+#----------------------------------------------------------------------------#
+
+app = Flask(__name__)
+app.config.from_object('config')
+db = SQLAlchemy(app)

--- a/Monitor/monitor_app/models.py
+++ b/Monitor/monitor_app/models.py
@@ -2,7 +2,9 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, Integer, String
-from app import db
+from appinit import db
+
+
 
 engine = create_engine('sqlite:///database.db', echo=True)
 db_session = scoped_session(sessionmaker(autocommit=False,

--- a/Monitor/monitor_app/monitor_tests.py
+++ b/Monitor/monitor_app/monitor_tests.py
@@ -1,0 +1,29 @@
+#-*- coding:utf-8 -*-
+import os
+from app import app
+import unittest
+import tempfile
+
+class MonitorTestCase(unittest.TestCase):
+
+    def setUp(self):
+        # print app.config['DATABASE']
+        self.db_fd, app.config['DATABASE'] = tempfile.mkstemp()
+        app.config['TESTING'] = True
+        app.config["MEDIACLOUD_DATABASE_HOST"] = 'localhost'
+        self.app = app.test_client()
+        #app.init_db()
+
+    def tearDown(self):
+        os.close(self.db_fd)
+        os.unlink(app.config['DATABASE'])
+
+    def test_mongo_query_with_empty_collections(self):
+        rv = self.app.get('/query/feeds')
+        self.assertIn('{"error": "ValueError(', rv.data)
+        rv = self.app.get('/query/articles')
+        self.assertIn('{"error": "ValueError(', rv.data)
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
This pull request adds a view to Monitor which will serve as a proxy to redirect query to MCDB (Mongodb).

This way we can handle the authentication in the flask app, and maintain the access  MongoDB strictly local.

The view only supports "find" queries.

I haven't added the _login_required_ decorator yet, since I want to first make sure that the query functionality is working before tackling the authentication issue.
