### PR TITLE
Reuters' crawler 

### DIFF
--- a/capture/crawler_estadao.py
+++ b/capture/crawler_estadao.py
@@ -41,6 +41,10 @@ mcdb = client.MCDB
 ARTICLES = mcdb.articles  # Article Collection
 ARTICLES.ensure_index("source")
 
+CATEGORIES = (u'politica', u'economia', u'internacional', u'esportes',
+                  u'sao-paulo', u'cultura', u'opiniao', u'alias', u'brasil',
+                  u'ciencia', u'educacao', u'saude', u'sustentabilidade',
+                  u'viagem')
 
 def find_articles(category, page=1):
     """Get the urls of last news and its categories
@@ -52,11 +56,6 @@ def find_articles(category, page=1):
        :return: last news with its categories
        :rtype: list()
     """
-
-    CATEGORIES = (u'politica', u'economia', u'internacional', u'esportes',
-                  u'sao-paulo', u'cultura', u'opiniao', u'alias', u'brasil',
-                  u'ciencia', u'educacao', u'saude', u'sustentabilidade',
-                  u'viagem')
 
     if category not in CATEGORIES:
         raise ValueError("Category value not accepted.")
@@ -184,11 +183,12 @@ def download_article(url):
     return article
 
 if __name__ == '__main__':
-    for url in find_articles(sys.argv[1], sys.argv[2]):
-        exists = list(ARTICLES.find({"link": url}))
-        if not exists:
-            article = download_article(url)
-            if article['body_content'] is None:
-                continue
-            ARTICLES.insert(article, w=1)
+    for category in CATEGORIES:
+        for url in find_articles(category):
+            exists = list(ARTICLES.find({"link": url}))
+            if not exists:
+                article = download_article(url)
+                if article['body_content'] is None:
+                    continue
+                ARTICLES.insert(article, w=1)
 

--- a/capture/crawler_reuters.py
+++ b/capture/crawler_reuters.py
@@ -1,0 +1,53 @@
+import logging
+import pymongo
+import settings
+import requests
+
+from goose import Goose
+from bs4 import BeautifulSoup
+from logging.handlers import RotatingFileHandler
+
+
+logger = logging.getLogger("Reuters")
+logger.setLevel(logging.DEBUG)
+
+stream_handler = logging.StreamHandler()
+stream_handler.setLevel(logging.DEBUG)
+file_handler = RotatingFileHandler('/tmp/mediacloud_reuters.log',
+                          maxBytes=5e6,
+                          backupCount=3)
+
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+# add formatter to stream_handler
+stream_handler.setFormatter(formatter)
+file_handler.setFormatter(formatter)
+
+# add stream_handler to logger
+logger.addHandler(stream_handler)  # uncomment for console output of messages
+logger.addHandler(file_handler)
+
+
+client = pymongo.MongoClient(settings.MONGOHOST, 27017)
+mcdb = client.MCDB
+ARTICLES = mcdb.articles
+ARTICLES.ensure_index("source")
+
+CATEGORIES = {u'mundo': u'worldNews', u'negocios': u'businessNews', u'esportes': u'sportsNews', u'cultura': u'entertainmentNews',u'brasil': u'domesticNews', u'internet': u'internetNews'}
+
+
+def find_article(category):
+
+    if category not in CATEGORIES:
+        raise ValueError("Category value not accepted.")
+    INDEX_URL = "http://br.reuters.com/news/archive/{0}?date=today".format(CATEGORIES[category])
+
+    index = requests.get(INDEX_URL).content
+    soup = BeautifulSoup(index)
+    news_index = soup.find("div", {"class": "module"})
+    urls = [a['href'] for a in news_index.findAll("a")]
+    news_urls = ["http://br.reuters.com{0}".format(url) for url in urls]
+    return news_urls
+
+if __name__ ==  "__main__":
+    find_article(u'mundo')

--- a/capture/crawler_reuters.py
+++ b/capture/crawler_reuters.py
@@ -36,7 +36,7 @@ ARTICLES.ensure_index("source")
 CATEGORIES = {u'mundo': u'worldNews', u'negocios': u'businessNews', u'esportes': u'sportsNews', u'cultura': u'entertainmentNews',u'brasil': u'domesticNews', u'internet': u'internetNews'}
 
 
-def find_article(category):
+def find_articles(category):
 
     if category not in CATEGORIES:
         raise ValueError("Category value not accepted.")
@@ -47,7 +47,10 @@ def find_article(category):
     news_index = soup.find("div", {"class": "module"})
     urls = [a['href'] for a in news_index.findAll("a")]
     news_urls = ["http://br.reuters.com{0}".format(url) for url in urls]
+    print(news_urls)
     return news_urls
 
-if __name__ ==  "__main__":
-    find_article(u'mundo')
+
+#
+# if __name__ ==  "__main__":
+#     find_articles(u'mundo')

--- a/capture/crawler_reuters.py
+++ b/capture/crawler_reuters.py
@@ -5,6 +5,7 @@ import requests
 
 from goose import Goose
 from bs4 import BeautifulSoup
+from downloader import compress_content, detect_language
 from logging.handlers import RotatingFileHandler
 
 
@@ -47,10 +48,17 @@ def find_articles(category):
     news_index = soup.find("div", {"class": "module"})
     urls = [a['href'] for a in news_index.findAll("a")]
     news_urls = ["http://br.reuters.com{0}".format(url) for url in urls]
-    print(news_urls)
     return news_urls
 
+def extract_title(article):
 
-#
-# if __name__ ==  "__main__":
-#     find_articles(u'mundo')
+    try:
+        title = article.title
+    except Exception as ex:
+        template = "An exception of type {0} occured during extraction of news title. Arguments:\n{1!r}"
+        message = template.format(type(ex).__name__, ex.args)
+        logger.exception(message)
+        return None
+    if title is None:
+        logger.error("The news title is None")
+    return title

--- a/capture/crawler_reuters.py
+++ b/capture/crawler_reuters.py
@@ -91,12 +91,14 @@ def extract_published_time(soup):
               u"Jul", u"agosto": u"Aug", u"setembro": u"Sep", u"outubro":
               u"Oct", u"novembro": u"Nov", u"dezembro": u"Dec"}
     time_tag = soup.find("div", {"class": "timestampHeader"}).text
-    time_pattern = re.compile("(.*), (\d{1,2}) de (.*) de (\d{4}) (.*) BRT")
-    groups = time_pattern.search(time_tag).groups()
-    day, month, year, time = [groups[i] for i in range(1, 5)]
-    date_str = "{0} {1} {2} {3}".format(day, MONTHS[month], year, time)
-    date = datetime.strptime(date_str, '%d %b %Y %H:%M')
-    return date
+    time_pattern = re.compile("(.*), (\d{1,2}) de (.*) de (\d{4}) (.*) BR(S)?T")
+    if time_tag is not None:
+        groups = time_pattern.search(time_tag).groups()
+        day, month, year, time = [groups[i] for i in range(1, 5)]
+        date_str = "{0} {1} {2} {3}".format(day, MONTHS[month], year, time)
+        date = datetime.strptime(date_str, '%d %b %Y %H:%M')
+        return date
+    return None
 
 
 def extract_content(article):

--- a/capture/crawler_reuters.py
+++ b/capture/crawler_reuters.py
@@ -112,8 +112,6 @@ def extract_content(article):
         if body_content is None:
             logger.error("The news content is None")
 
-        last_word = body_content.strip().split().pop().lower()
-
         return body_content
 
 
@@ -143,6 +141,10 @@ def download_article(url):
     return article
 
 if __name__ == '__main__':
-    for url in find_articles('negocios', '10022015'):
-        article = download_article(url)
-        print(article['body_content'])
+    for url in find_articles('negocios', 'today'):
+        exists = list(ARTICLES.find({"link": url}))
+        if not exists:
+            article = download_article(url)
+            if article['body_content'] is None:
+                continue
+            ARTICLES.insert(article, w=1)

--- a/capture/crawler_reuters.py
+++ b/capture/crawler_reuters.py
@@ -83,3 +83,18 @@ def extract_published_time(soup):
     date_str = "{0} {1} {2} {3}".format(day, MONTHS[month], year, time)
     date = datetime.strptime(date_str, '%d %b %Y %H:%M')
     return date
+
+
+def extract_content(article):
+
+        try:
+            body_content = article.cleaned_text
+        except Exception as ex:
+            template = "An exception of type {0} occured during extraction of news\
+                        content. Arguments:\n{1!r}"
+            message = template.format(type(ex).__name__, ex.args)
+            logger.exception(message)
+            return None
+        if body_content is None:
+            logger.error("The news content is None")
+        return body_content

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,5 @@ sphinxit
 goose-extractor
 elasticsearch
 urllib3
+Pillow
 -e git@github.com:lucasmachadorj/python-goose.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ sphinxit
 goose-extractor
 elasticsearch
 urllib3
+-e git@github.com:lucasmachadorj/python-goose.git


### PR DESCRIPTION
@flavioamieiro please, review this code . It's necessary to run it with python 3.

As discussed with @fccoelho I'm porting the crawlers to python 3 and was also necessary to port goose-extractor, which is here: https://github.com/lucasmachadorj/python-goose
With this version, we can extract title and content without errors, but I will work to make the whole package compatible with python 2 and 3.
Furthermore, it's necessary to use this version of lxml: https://github.com/lucasmachadorj/lxml
lxml makes use of beautifulSoup, which is not compatible with python 3, but the above version fix this problem. The only script really used from lxml by goose is soupparser: https://github.com/lucasmachadorj/lxml/blob/master/src/lxml/html/soupparser.py

 Install lxml from source is a bit complex and I don't know the best way we can do it.
